### PR TITLE
Make database backups each run

### DIFF
--- a/seasonwatch/app.py
+++ b/seasonwatch/app.py
@@ -36,6 +36,7 @@ def main() -> int:
     if not Constants.DATA_DIRECTORY.exists():
         os.mkdir(Constants.DATA_DIRECTORY)
 
+    Sql.backup_database()
     Sql.ensure_table()
 
     try:

--- a/seasonwatch/constants.py
+++ b/seasonwatch/constants.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 class Constants:
     DATA_DIRECTORY = Path.home() / ".seasonwatch"
-    DATABASE_PATH = str(DATA_DIRECTORY / "database.sqlite")
+    DATABASE_FILE = "database.sqlite"
+    DATABASE_PATH = str(DATA_DIRECTORY / DATABASE_FILE)
 
     SERIES_TABLE = "series"
     MOVIES_TABLE = "movies"

--- a/seasonwatch/sql.py
+++ b/seasonwatch/sql.py
@@ -1,6 +1,11 @@
+import os
+import shutil
+from pathlib import Path
+
 import apsw
 
 from seasonwatch.constants import Constants
+from seasonwatch.utils import Utils
 
 
 class Sql:
@@ -35,6 +40,23 @@ class Sql:
         )
         cursor.execute("COMMIT TRANSACTION")
         connection.close()
+
+    @staticmethod
+    def backup_database() -> None:
+        N_BACKUPS = 10
+        if Path(Constants.DATABASE_PATH).exists():
+            backup_path = Path(
+                Constants.DATA_DIRECTORY / str(Utils.timestamp() + "_database.sqlite")
+            )
+            shutil.copyfile(Constants.DATABASE_PATH, backup_path)
+
+        dir_content = os.listdir(Constants.DATA_DIRECTORY)
+        dir_content.remove(Constants.DATABASE_FILE)
+        dir_content.sort(reverse=True)
+        files_to_remove = set(dir_content).difference(set(dir_content[0:N_BACKUPS]))
+        for file in files_to_remove:
+            if "database" in file:
+                os.remove(Constants.DATA_DIRECTORY / file)
 
     @staticmethod
     def update_series(

--- a/seasonwatch/utils.py
+++ b/seasonwatch/utils.py
@@ -68,3 +68,7 @@ class Utils:
             return None
 
         return next_episode_id
+
+    @staticmethod
+    def timestamp() -> str:
+        return datetime.now().strftime("%Y-%m-%d_%H-%M-%S")


### PR DESCRIPTION
Each time seasonwatch is run, a timestamped backup of the database is now created.
