### PR TITLE
Set discogs token through CLI

### DIFF
--- a/seasonwatch/app.py
+++ b/seasonwatch/app.py
@@ -1,6 +1,6 @@
 import logging
-import os
 import sys
+from configparser import ConfigParser
 
 import gi
 
@@ -27,8 +27,18 @@ def main() -> int:
     Sql.backup_database()
     Sql.ensure_table()
 
+    if not Constants.DATA_DIRECTORY.exists():
+        Constants.DATA_DIRECTORY.mkdir(parents=True, exist_ok=True)
+
+    if not Constants.CONFIG_DIRECTORY.exists():
+        Constants.CONFIG_DIRECTORY.mkdir(parents=True, exist_ok=True)
+    if not (Constants.CONFIG_PATH).exists():
+        (Constants.CONFIG_PATH).touch()
+
     args = Cli.parse()
     if args.subparser_name == "configure":
+        if args.discogs_token:
+            Configure.discogs_token()
         if args.series:
             Configure.series()
         if args.artists:
@@ -39,11 +49,14 @@ def main() -> int:
     ia: IMDbHTTPAccessSystem = Cinemagoer(accessSystem="https")
     watcher = MediaWatcher()
 
-    if not Constants.DATA_DIRECTORY.exists():
-        os.mkdir(Constants.DATA_DIRECTORY)
+    config = ConfigParser()
+    config.read(Constants.CONFIG_PATH)
 
+    discogs_token = None
+    if config.has_option("Tokens", "discogs_token"):
+        discogs_token = config.get("Tokens", "discogs_token")
     try:
-        watcher.check_for_new_music()
+        watcher.check_for_new_music(discogs_token)
     except SeasonwatchException as e:
         logging.error(
             f"Seasonwatch encountered an error when checking for new music: {e}"

--- a/seasonwatch/cli.py
+++ b/seasonwatch/cli.py
@@ -34,4 +34,13 @@ class Cli:
             required=False,
         )
 
+        configure.add_argument(
+            "-d",
+            "--discogs-token",
+            help="Configure a discogs token necessary when checking for new music.",
+            action="store_true",
+            dest="discogs_token",
+            required=False,
+        )
+
         return parser.parse_args()

--- a/seasonwatch/config.py
+++ b/seasonwatch/config.py
@@ -1,3 +1,6 @@
+from configparser import ConfigParser
+
+from seasonwatch.constants import Constants
 from seasonwatch.exceptions import SeasonwatchException
 from seasonwatch.sql import Sql
 
@@ -70,3 +73,20 @@ class Configure:
 
             print("")
             add_more = True if input("Add more artists? (y/N) ") == "y" else False
+
+    @staticmethod
+    def discogs_token() -> None:
+        """Set the discogs token.
+
+        Set the discogs token used for interacting with discogs when
+        checking for new music.
+        """
+        token = input("Discogs API token: ")
+        if token != "":
+
+            parser = ConfigParser()
+            parser.add_section("Tokens")
+            parser.set("Tokens", "discogs_token", token)
+
+            with open(Constants.CONFIG_DIRECTORY / Constants.CONFIG_FILE, "w") as f:
+                parser.write(f)

--- a/seasonwatch/constants.py
+++ b/seasonwatch/constants.py
@@ -3,6 +3,9 @@ from pathlib import Path
 
 class Constants:
     DATA_DIRECTORY = Path.home() / ".seasonwatch"
+    CONFIG_DIRECTORY = Path.home() / ".config" / "seasonwatch"
+    CONFIG_FILE = "config"
+    CONFIG_PATH = CONFIG_DIRECTORY / CONFIG_FILE
     DATABASE_FILE = "database.sqlite"
     DATABASE_PATH = str(DATA_DIRECTORY / DATABASE_FILE)
 

--- a/seasonwatch/media_watcher.py
+++ b/seasonwatch/media_watcher.py
@@ -103,7 +103,15 @@ class MediaWatcher:
                 )
                 self.series["later"][name] = message
 
-    def check_for_new_music(self) -> None:
+    def check_for_new_music(self, discogs_token: str | None) -> None:
+        artists = Sql.read_all_artists()
+        music_data = Sql.read_all_music()
+
+        if len(artists) > 0 and discogs_token is None:
+            raise SeasonwatchException(
+                "Cannot check for new music since no discogs API token was found."
+            )
+
         with open("discogs_token") as f:
             discogs_token = f.readline()
         d = discogs_client.Client(
@@ -111,8 +119,6 @@ class MediaWatcher:
             user_token=discogs_token.strip(),
         )
 
-        artists = Sql.read_all_artists()
-        music_data = Sql.read_all_music()
         for artist in artists:
             artist_id = artist["id"]
             old_albums = [a for a in music_data if a["artist_id"] == artist_id]


### PR DESCRIPTION
Ability to set the discogs API token through the configure verb has been added. The key is saved to ~/.config/seasonwatch/config, which is an ini file.
