### PR TITLE
Remove trying to read old config

### DIFF
--- a/seasonwatch/media_watcher.py
+++ b/seasonwatch/media_watcher.py
@@ -112,11 +112,9 @@ class MediaWatcher:
                 "Cannot check for new music since no discogs API token was found."
             )
 
-        with open("discogs_token") as f:
-            discogs_token = f.readline()
         d = discogs_client.Client(
             "Seasonwatch",
-            user_token=discogs_token.strip(),
+            user_token=discogs_token,
         )
 
         for artist in artists:


### PR DESCRIPTION
Seasonwatch was trying to read an old config for the discogs API key.
This should have been removed in an earlier commit from whence the new
config was used.
