### PR TITLE
Fix problem with missing release dates

### DIFF
--- a/seasonwatch/utils.py
+++ b/seasonwatch/utils.py
@@ -18,29 +18,23 @@ class Utils:
         next_episode_id: str,
         ia: IMDbHTTPAccessSystem,
     ) -> datetime:
-        imdb_release_data = ia.get_movie_release_dates(next_episode_id).get("data")
+        episode = ia.get_movie(next_episode_id)
+        episode_air_date = episode.get("original air date")
 
         # There is no data about the release date of the new season
-        if imdb_release_data is None:
+        if episode_air_date is None:
             print(
                 f"Season {next_season} of {title} is announced but "
                 "the release date is not yet determined"
             )
 
-        # Parse date from release dates of all countries and take the minimum
-        imdb_raw_release_dates = imdb_release_data.get("raw release dates")
-        if imdb_raw_release_dates is None:
-            raise SeasonwatchException(f"Couldn't find IMDb release dates for {title}")
+        if not isinstance(episode_air_date, str):
+            raise SeasonwatchException("Something is wrong with the air date data")
 
-        try:
-            next_season_earliest_release: datetime = min(
-                parse(d["date"], default=datetime(2022, 12, 31))
-                for d in imdb_raw_release_dates
-            )
-        except ParserError as e:
-            raise Exception(
-                f"There was an error parsing date value for the show {title}: {e}"
-            )
+        next_season_earliest_release: datetime = parse(
+            episode_air_date,
+            default=datetime(2022, 12, 31),
+        )
 
         return next_season_earliest_release
 


### PR DESCRIPTION
There is a bug with Cinemagoer where release dates are missing.
Seasonwatch now uses the "original air date" data instead, which is
still available, fixing the problem.
