### PR TITLE
Remove reference to music tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 ## Introduction
 
-**seasonwatch** is a script that helps you keep track of when new seasons of
-TV shows you are following are released and when new albums of artists you are
-interested in drop.
+**seasonwatch** is an app that helps you keep track of when new seasons of TV
+shows you are following are released.
 
 ## Installation
 
@@ -53,24 +52,7 @@ is: https://www.imdb.com/title/tt3230854/?ref_=fn_al_tt_1
 the ID is the number that comes after "tt" in the URL, and before the first '/'
 after that, that is '3230854'.
 
-Adding an artist works in a similar way. First, run:
-
-```
-$ seasonwatch configure --artist
-```
-
-Then, if you want to follow e.g. Abul Mogard, find his page in discogs.com, get
-the ID from there, and fill it in:
-
-```text
-Name of the artist: Abul Mogard
-ID of the artist (number after 'artist' in the Discogs url): 2803639
-```
-
-The URL in this case is: https://www.discogs.com/artist/2803639-Abul-Mogard
-where the ID should be easy to see.
-
-### Checking for new seasons or albums
+### Checking for new seasons
 
 Just run seasonwatch like so:
 
@@ -84,13 +66,13 @@ the script with e.g. a cron job that runs it regularly.
 
 ## Development
 
-seasonwatch currently supports checking for new TV show seasons and new albums
-by artists. Version 0.1.0 has been released and it should be good to use by
-anyone.
+seasonwatch currently supports checking for new TV show seasons only. Version
+0.2.0 has been released and it should be good to use by anyone.
 
 ### Bugs
 
-Report bugs under the [issues](https://github.com/gevhaz/seasonwatch/issues) tab here on Github.
+Report bugs under the [issues](https://github.com/gevhaz/seasonwatch/issues) tab
+here on Github.
 
 ### Planned features
 


### PR DESCRIPTION
Seasonwatch cannot track music releases, and the README should reflect this.

Closes #41