### PR TITLE
Track ID source in database and handle both

### DIFF
--- a/seasonwatch/config.py
+++ b/seasonwatch/config.py
@@ -1,3 +1,4 @@
+from seasonwatch.constants import Source
 from seasonwatch.exceptions import SeasonwatchException
 from seasonwatch.sql import Sql
 
@@ -60,15 +61,16 @@ class Configure:
 
     @staticmethod
     def add_series() -> None:
-        """
-        Function for adding TV-shows to the database. Requests user from
+        """Interactively add one or more TV-shows to the database.
+
+        Add one or more TV-shows to the database. Requests user from
         the input and the updates the database, with default values for
         that which the user doesn't provide.
         """
         add_more = True
         while add_more:
-            title = input("Title of the show: ")
-            id = input("ID of the show (after 'tt' in the url on IMDB): ")
+            title = input("What the show should be called: ")
+            id = input("ID of the show (after 'tv/' in the URL on TMDB): ")
             last_season = input("Last watched season: ")
 
             try:
@@ -77,7 +79,7 @@ class Configure:
                 raise SeasonwatchException(f"Couldn't parse '{last_season}' as an int")
 
             print(f"title: {title}")
-            print(f"ID: {id}")
+            print(f"TMDB ID: {id}")
             print(f"Last watched season: {last_season}")
             ok = False if input("Does this look ok? (Y/n) ") == "n" else True
 
@@ -89,6 +91,7 @@ class Configure:
                     0,
                     "1970-01-01 00:00:00",
                     "1970-01-01 00:00:00",
+                    Source.TMDB,
                 )
             else:
                 print("Data was not saved")

--- a/seasonwatch/constants.py
+++ b/seasonwatch/constants.py
@@ -1,4 +1,5 @@
 import os
+from enum import Enum
 from pathlib import Path
 from typing import Final
 
@@ -15,3 +16,10 @@ class Constants:
 
     API_VERSION: Final[str] = "3"
     API_BASE_URL: Final[str] = f"https://api.themoviedb.org/{API_VERSION}"
+
+
+class Source(Enum):
+    """Enum with accepted TV Series information sources."""
+
+    IMDB = "IMDb"
+    TMDB = "TMDB"

--- a/seasonwatch/media_watcher.py
+++ b/seasonwatch/media_watcher.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 from imdb.parser.http import IMDbHTTPAccessSystem
 
+from seasonwatch.constants import Source
 from seasonwatch.exceptions import SeasonwatchException
 from seasonwatch.sql import Sql
 from seasonwatch.utils import Utils
@@ -37,6 +38,10 @@ class MediaWatcher:
             next_season = last_watched_season + 1
             name = series["title"]
             id = series["id"]
+            source = series["id_source"]
+            if source == Source.TMDB:
+                print(f"TMDB not yet supported. Skipping '{name}'")
+                continue
 
             old_data = Sql.read_series(id)
 
@@ -49,6 +54,7 @@ class MediaWatcher:
                 int(old_data.get("last_season", 0)),
                 last_change,
                 last_notify,
+                source,
             )
 
             try:


### PR DESCRIPTION
New TV shows are now required to provide the TMDB ID instead of the IMDb
ID. An `id_source` field has been added to the database, which defaults
to IMDb if it doesn't exist since before (since that means seasonwatch
hasn't been run since this change). This ensures some degree of backward
compatibality, so that users don't need to rebuild their database. More
functionality is required to find the TMDB ID of existing shows in the
database, based on their IMDb ID. TMDB is not yet fully supported, so
shows with that source are simply skipped for now.

Closes #39 
