### PR TITLE
Translate IMDb IDs to TMDB

### DIFF
--- a/seasonwatch/app.py
+++ b/seasonwatch/app.py
@@ -5,6 +5,7 @@ from configparser import ConfigParser
 import gi
 import requests
 from prettytable.prettytable import SINGLE_BORDER
+from requests import Session
 from requests.exceptions import HTTPError
 
 gi.require_version("Notify", "0.7")
@@ -97,8 +98,16 @@ def main() -> int:
     ia: IMDbHTTPAccessSystem = Cinemagoer(accessSystem="https")
     watcher = MediaWatcher()
 
+    tmdb_session = Session()
+    tmdb_session.headers.update(
+        {
+            "accept": "application/json",
+            "Authorization": f"Bearer {tmdb_token}",
+        }
+    )
+
     try:
-        watcher.check_for_new_seasons(ia)
+        watcher.check_for_new_seasons(session=tmdb_session, ia=ia)
     except SeasonwatchException as e:
         logging.error(
             f"Seasonwatch encountered an error when checking for new seasons: {e}"

--- a/seasonwatch/media_watcher.py
+++ b/seasonwatch/media_watcher.py
@@ -1,8 +1,9 @@
 from datetime import datetime, timedelta
 
 from imdb.parser.http import IMDbHTTPAccessSystem
+from requests import HTTPError, Session
 
-from seasonwatch.constants import Source
+from seasonwatch.constants import Constants, Source
 from seasonwatch.exceptions import SeasonwatchException
 from seasonwatch.sql import Sql
 from seasonwatch.utils import Utils
@@ -21,8 +22,38 @@ class MediaWatcher:
             "nothing": {},
         }
 
+    def translate_imdb_id(
+        self,
+        session: Session,
+        imdb_id: str,
+    ) -> tuple[str | None, str | None]:
+        """Suggest TMDB ID with corresponding name for given IMDb ID."""
+        imdb_id = f"tt{imdb_id:0>7}"
+        url = f"{Constants.API_BASE_URL}/find/{imdb_id}?external_source=imdb_id"
+        try:
+            response = session.get(url)
+            response.raise_for_status()
+        except HTTPError as e:
+            raise SeasonwatchException(
+                f"Failure connecting to TMDB for converting IMDb ID: {e}"
+            )
+        response = response.json()
+        if not isinstance(response, dict):
+            raise SeasonwatchException(
+                "Malformed data returned from TMDB when attemping to find TMDB ID."
+            )
+        tv_results_list = response.get("tv_results")
+        if not tv_results_list or not len(tv_results_list) > 0:
+            return None, None
+        tv_result = tv_results_list[0]
+
+        title = tv_result.get("original_name")
+        id = tv_result.get("id")
+        return id, title
+
     def check_for_new_seasons(
         self,
+        session: Session,
         ia: IMDbHTTPAccessSystem,
     ) -> None:
         """
@@ -33,25 +64,50 @@ class MediaWatcher:
         returned for further use.
         """
         series_data = Sql.read_all_series()
+        last_change = Utils.sql_today()
+        last_notify = Utils.sql_today()
         for series in series_data:
             last_watched_season = int(series["last_season"])
+            checks = int(series.get("last_check", 0)) + 1
             next_season = last_watched_season + 1
             name = series["title"]
             id = series["id"]
             source = series["id_source"]
-            if source == Source.TMDB:
+            if source == Source.IMDB:
+                tmdb_id, tmdb_name = self.translate_imdb_id(session, id)
+                print(f"Attempting to convert ID from IMDb to TMDB for series: {name}")
+                looks_ok = False
+                if tmdb_id:
+                    print(f"Found TMDB ID {tmdb_id} with associated name '{tmdb_name}'")
+                    looks_ok = input("Does it look okay? [Y/n]: ") not in ["n", "N"]
+                if not looks_ok or not tmdb_id:
+                    print("Couldn't automatically find the ID for above series.")
+                    print("Please enter it manually (after tv/ in TMDB URL): ")
+                    tmdb_id = input("TMDB ID (empty skips for now): ")
+                    if tmdb_id == "":
+                        print(f"Skipping '{name}'...")
+                        continue
+                Sql.update_series(
+                    id,
+                    name,
+                    last_watched_season,
+                    checks,
+                    last_change,
+                    last_notify,
+                    Source.TMDB,
+                    full_replace=True,
+                )
+                print(f"Successfully migrated series '{name}' from IMDb to TMDB")
+                continue
+            else:
                 print(f"TMDB not yet supported. Skipping '{name}'")
                 continue
 
-            old_data = Sql.read_series(id)
-
-            last_change = Utils.sql_today()
-            last_notify = Utils.sql_today()
             Sql.update_series(
                 id,
                 name,
                 last_watched_season,
-                int(old_data.get("last_season", 0)),
+                checks,
                 last_change,
                 last_notify,
                 source,


### PR DESCRIPTION
Added ability to convert IMDb ID to TMDB ID whenever a series that has an IMDb ID is discovered. The migration is mandatory since IMDb no longer works. An attempt to automatically find the corresponding TMDB ID based on information from TMDB's own database will be performed, but the user can reject the suggestion and fill in the new ID manually. If the search fails, the user has to fill it in manually.

Closes #46 