### PR TITLE
Fix bug when no air date is available

### DIFF
--- a/seasonwatch/media_watcher.py
+++ b/seasonwatch/media_watcher.py
@@ -118,6 +118,8 @@ class MediaWatcher:
                     "date is unknown"
                 )
                 self.series["nothing"][name] = message
+                continue
+
             if not isinstance(next_air_date_raw, str):
                 raise SeasonwatchException(
                     f"Malformed air date returned from TMDB: {next_air_date_raw}"


### PR DESCRIPTION
Fixes #68. The issue was that the loop iteration is not broken when it should be after checking if the air date is available.
